### PR TITLE
add ellipsis for arena chat tabs

### DIFF
--- a/web/design/css/pregame/arenamain.css
+++ b/web/design/css/pregame/arenamain.css
@@ -741,6 +741,7 @@ body {
     color:#4b4b4b;
     line-height:30px;
     outline:none;
+    text-overflow: ellipsis;
 }
 .chat .tickbar .con_ticks .ticks .tick .active{
     background-color:white;


### PR DESCRIPTION
to show that chat tab name is longer that chat tab size it's better to add ellipsis at the end of text